### PR TITLE
Query `ONS_CIS_New.visit_num`

### DIFF
--- a/analysis/visit_num.csv
+++ b/analysis/visit_num.csv
@@ -1,0 +1,1 @@
+visit_num,num_rows

--- a/analysis/visit_num.sql
+++ b/analysis/visit_num.sql
@@ -1,0 +1,6 @@
+SELECT
+    visit_num,
+    COUNT(*) AS num_rows
+FROM ONS_CIS_New
+GROUP BY visit_num
+ORDER BY visit_num

--- a/project.yaml
+++ b/project.yaml
@@ -4,3 +4,11 @@ expectations:
   population_size: 1000
 
 actions:
+  visit_num:
+    run: sqlrunner:latest
+      --output output/raw/visit_num.csv
+      --dummy-data-file analysis/visit_num.csv
+      analysis/visit_num.sql
+    outputs:
+      moderately_sensitive:
+        rows: output/raw/visit_num.csv


### PR DESCRIPTION
Count the number of rows for each value of `ONS_CIS_New.visit_num`. We expect this column to be an ordinal mapping from integers in the range `[0, 15]` to weeks/months since enrolment.