### PR TITLE
Add `make_safe` action

### DIFF
--- a/analysis/make_safe.py
+++ b/analysis/make_safe.py
@@ -1,0 +1,52 @@
+from argparse import ArgumentParser
+import csv
+import json
+from pathlib import Path
+
+import sdc
+
+
+def main():
+    args = parse_args()
+    for table in args["config"]["tables"]:
+        make_safe(table["from"], table["columns"], table["to"])
+
+
+def parse_args():
+    parser = ArgumentParser()
+    parser.add_argument("--config", type=json.loads)
+    return vars(parser.parse_args())
+
+
+def make_safe(in_, columns_to_make_safe, out_):
+    p_in = Path(in_)
+    p_out = Path(out_)
+    p_out.parent.mkdir(parents=True, exist_ok=True)
+
+    args = {"newline": ""}
+    with p_in.open("r", **args) as f_in, p_out.open("w", **args) as f_out:
+        reader = csv.reader(f_in)
+        writer = csv.writer(f_out)
+
+        header = next(reader)
+        writer.writerow(header)
+
+        # Do values in each column need to be made safe?
+        make_safe_flags = [x in columns_to_make_safe for x in header]
+        for row in reader:
+            # Starting with safe_row as an empty list ensures that we copy in either
+            # values that have been made safe or values that do not need making safe.
+            safe_row = []
+            for value, make_safe_flag in zip(row, make_safe_flags):
+                if make_safe_flag:
+                    value = int(value)
+                    # This is where we make the unsafe value a safe value.
+                    value = sdc.redact_le_seven(value)
+                    value = sdc.round_to_nearest_five(value)
+                safe_row.append(value)
+            assert len(row) == len(safe_row)
+            writer.writerow(safe_row)
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/sdc.py
+++ b/analysis/sdc.py
@@ -1,0 +1,20 @@
+"""Statistical Disclosure Control (SDC) functions.
+
+For more information, see:
+https://docs.opensafely.org/releasing-files/
+"""
+import functools
+
+
+def redact_le(value, threshold):
+    return 0 if value <= threshold else value
+
+
+redact_le_seven = functools.partial(redact_le, threshold=7)
+
+
+def round_to_nearest(value, multiple):
+    return int(multiple * round(value / multiple, 0))
+
+
+round_to_nearest_five = functools.partial(round_to_nearest, multiple=5)

--- a/justfile
+++ b/justfile
@@ -1,0 +1,7 @@
+# List commands
+default:
+    @"{{ just_executable() }}" --list
+
+# Run the tests
+test *args:
+    opensafely exec python:latest pytest {{ args }}

--- a/project.yaml
+++ b/project.yaml
@@ -10,7 +10,7 @@ actions:
       --dummy-data-file analysis/visit_num.csv
       analysis/visit_num.sql
     outputs:
-      moderately_sensitive:
+      highly_sensitive:
         rows: output/raw/visit_num.csv
 
   make_safe:

--- a/project.yaml
+++ b/project.yaml
@@ -12,3 +12,15 @@ actions:
     outputs:
       moderately_sensitive:
         rows: output/raw/visit_num.csv
+
+  make_safe:
+    needs: [visit_num]
+    run: python:latest python analysis/make_safe.py
+    config:
+      tables:
+        - from: output/raw/visit_num.csv
+          to: output/safe/visit_num.csv
+          columns: [num_rows]
+    outputs:
+      moderately_sensitive:
+        rows: output/safe/*.csv

--- a/tests/test_sdc.py
+++ b/tests/test_sdc.py
@@ -1,0 +1,13 @@
+import pytest
+
+from analysis import sdc
+
+
+@pytest.mark.parametrize("data_in,data_out", [(6, 0), (7, 0), (8, 8)])
+def test_redact_le_seven(data_in, data_out):
+    assert sdc.redact_le_seven(data_in) == data_out
+
+
+@pytest.mark.parametrize("data_in,data_out", [(1, 0), (3, 5), (5, 5), (7, 5), (9, 10)])
+def test_round_to_nearest_five(data_in, data_out):
+    assert sdc.round_to_nearest_five(data_in) == data_out


### PR DESCRIPTION
This action applies SDC functions to any CSV files given by the configuration. Rather than overwriting these files, it copies them from one location to another location. Here, these locations are clearly labelled *raw* and *safe* directories.